### PR TITLE
Implemented new auth method `access token of GCE(Google Compute Engine)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Google Cloud Storage output plugin for [Embulk](https://github.com/embulk/embulk
 - **path_prefix**: Prefix of output keys (string, required)
 - **file_ext**: Extention of output file (string, required)
 - **content_type**: content type of output file (string, optional, default value is "application/octet-stream")
+- **auth_method**: Authentication method `private_key` or `compute_engine` (string, optional, default value is "private_key")
 - **service_account_email**: Google Cloud Platform service account email (string, required)
 - **p12_keyfile_path**: Private key file fullpath of Google Cloud Platform service account (string, required)
 - **application_name**: Application name, anything you like (string, optional, default value is "embulk-output-gcs")
@@ -27,11 +28,35 @@ out:
   bucket: your-gcs-bucket-name
   path_prefix: logs/out
   file_ext: .csv
+  auth_method: `private_key` #default
   service_account_email: 'XYZ@developer.gserviceaccount.com'
   p12_keyfile_path: '/path/to/private/key.p12'
   formatter:
     type: csv
     encoding: UTF-8
+```
+
+## Authentication
+
+There are two methods supported to fetch access token for the service account.
+
+1. Public-Private key pair
+2. Pre-defined access token (Compute Engine only)
+
+The examples above use the first one.  You first need to create a service account (client ID),
+download its private key and deploy the key with embulk.
+
+On the other hand, you don't need to explicitly create a service account for embulk when you
+run embulk in Google Compute Engine. In this second authentication method, you need to
+add the API scope "https://www.googleapis.com/auth/devstorage.read_write" to the scope list of your
+Compute Engine instance, then you can configure embulk like this.
+
+[Setting the scope of service account access for instances](https://cloud.google.com/compute/docs/authentication)
+
+```yaml
+out:
+  type: gcs
+  auth_method: compute_engine
 ```
 
 ## Build

--- a/src/main/java/org/embulk/output/GcsAuthentication.java
+++ b/src/main/java/org/embulk/output/GcsAuthentication.java
@@ -1,0 +1,96 @@
+package org.embulk.output;
+
+import java.io.File;
+import java.io.IOException;
+
+import com.google.api.client.http.apache.ApacheHttpTransport;
+import com.google.api.services.storage.model.Objects;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import java.security.GeneralSecurityException;
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.googleapis.compute.ComputeCredential;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.services.storage.Storage;
+import com.google.api.services.storage.StorageScopes;
+import org.embulk.spi.Exec;
+import org.slf4j.Logger;
+
+public class GcsAuthentication
+{
+	private final Logger log = Exec.getLogger(GcsAuthentication.class);
+	private final Optional<String> serviceAccountEmail;
+	private final Optional<String> p12KeyFilePath;
+	private final String applicationName;
+	private final HttpTransport httpTransport;
+	private final JsonFactory jsonFactory;
+	private final HttpRequestInitializer credentials;
+
+	public GcsAuthentication(String authMethod, Optional<String> serviceAccountEmail, Optional<String> p12KeyFilePath, String applicationName)
+			throws IOException, GeneralSecurityException
+	{
+		this.serviceAccountEmail = serviceAccountEmail;
+		this.p12KeyFilePath = p12KeyFilePath;
+		this.applicationName = applicationName;
+
+		this.httpTransport = new ApacheHttpTransport.Builder().build();
+		this.jsonFactory = new JacksonFactory();
+
+		if (authMethod.equals("compute_engine")) {
+			this.credentials = getComputeCredential();
+		} else {
+			this.credentials = getServiceAccountCredential();
+		}
+	}
+
+	/**
+	 * @see https://developers.google.com/accounts/docs/OAuth2ServiceAccount#authorizingrequests
+	 */
+	private GoogleCredential getServiceAccountCredential() throws IOException, GeneralSecurityException
+	{
+		// @see https://cloud.google.com/compute/docs/api/how-tos/authorization
+		// @see https://developers.google.com/resources/api-libraries/documentation/storage/v1/java/latest/com/google/api/services/storage/STORAGE_SCOPE.html
+		// @see https://developers.google.com/resources/api-libraries/documentation/bigquery/v2/java/latest/com/google/api/services/bigquery/BigqueryScopes.html
+		return new GoogleCredential.Builder()
+				.setTransport(httpTransport)
+				.setJsonFactory(jsonFactory)
+				.setServiceAccountId(serviceAccountEmail.orNull())
+				.setServiceAccountScopes(
+						ImmutableList.of(
+								StorageScopes.DEVSTORAGE_READ_WRITE
+						)
+				)
+				.setServiceAccountPrivateKeyFromP12File(new File(p12KeyFilePath.orNull()))
+				.build();
+	}
+
+	/**
+	 * @see http://developers.guge.io/accounts/docs/OAuth2ServiceAccount#creatinganaccount
+	 * @see https://developers.google.com/accounts/docs/OAuth2
+	 */
+	private ComputeCredential getComputeCredential() throws IOException
+	{
+		ComputeCredential credential = new ComputeCredential.Builder(httpTransport, jsonFactory)
+				.build();
+		credential.refreshToken();
+
+		return credential;
+	}
+
+	public Storage getGcsClient(String bucket) throws GoogleJsonResponseException, IOException
+	{
+		Storage client = new Storage.Builder(httpTransport, jsonFactory, credentials)
+				.setApplicationName(applicationName)
+				.build();
+
+		// For throw IOException when authentication is fail.
+		long maxResults = 1;
+		Objects objects = client.objects().list(bucket).setMaxResults(maxResults).execute();
+
+		return client;
+	}
+}


### PR DESCRIPTION
This pull-request contains new implementation that enable to use `GCE pre-defined access token` authentication.

If we add devstorage.read_write scope when creating GCE VM instances,
we don't have to set both service_account_email and p12_keyfile_path options.

Because we can get OAuth access-token in GCE VM instances like below.

```
$ curl "http://metadata/computeMetadata/v1/instance/service-accounts/default/token" -H "X-Google-Metadata-Request: True"
{"access_token":"XXXXXXXXXX","expires_in":3599,"token_type":"Bearer"}
```
