### PR TITLE
mapreduce-executor support - Accept local file content in config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Google Cloud Storage output plugin for [Embulk](https://github.com/embulk/embulk
 - **content_type**: content type of output file (string, optional, default value is "application/octet-stream")
 - **auth_method**: Authentication method `private_key` or `compute_engine` (string, optional, default value is "private_key")
 - **service_account_email**: Google Cloud Platform service account email (string, required)
-- **p12_keyfile_path**: Private key file fullpath of Google Cloud Platform service account (string, required)
+- **p12_keyfile**: Private key file fullpath of Google Cloud Platform service account (string, required)
 - **application_name**: Application name, anything you like (string, optional, default value is "embulk-output-gcs")
 
 ## Example
@@ -30,7 +30,7 @@ out:
   file_ext: .csv
   auth_method: `private_key` #default
   service_account_email: 'XYZ@developer.gserviceaccount.com'
-  p12_keyfile_path: '/path/to/private/key.p12'
+  p12_keyfile: '/path/to/private/key.p12'
   formatter:
     type: csv
     encoding: UTF-8


### PR DESCRIPTION
This pull-request contains mapreduce-executor support.

Embulk supports distributed executors such as [embulk-executor-mapreduce](https://github.com/embulk/embulk-executor-mapreduce).
Those executors run tasks on remote server.
Including local file path in TaskSource may task filed on remote server because the file is not there.

[org.embulk.spi.unit.LocalFile](https://github.com/embulk/embulk/blob/master/embulk-core/src/main/java/org/embulk/spi/unit/LocalFile.java) is added since embulk [v0.6.16](http://www.embulk.org/docs/release/release-0.6.16.html) to solve
this problem. It reads content from the local file path when it's
initialized.

I changed option name from p12_keyfile_path to p12_keyfile.
p12_keyfile_path option still remains for backword compatibility.
## Usage

```
out:
  type: gcs
  auth_method: private_key
  p12_keyfile: /path/to/p12_keyfile.json
```

It also accepts embedding content of a file in config file.
## Usage

```
out:
  type: gcs
  auth_method: private_key
  p12_keyfile:
    base64: |
      base64: |
      aG9nZQpob2dlCmhvZ2UKaG9nZQpob2dlCmhvZ2UKaG9nZQpob2dlCmhvZ2UKaG9nZQpob2dlCmhv
      Z2UKaG9nZQpob2dlCmhvZ2UKaG9nZQpob2dlCmhvZ2UKaG9nZQpob2dlCmhvZ2UKaG9nZQpob2dl
      CmhvZ2UKaG9nZQpob2dlCmhvZ2UKaG9nZQpob2dlCmhvZ2UKaG9nZQpob2dlCmhvZ2UKaG9nZQpo
      b2dlCmhvZ2UKaG9nZQpob2dlCmhvZ2UKaG9nZQpob2dlCmhvZ2UKaG9nZQpob2dlCmhvZ2UKaG9n
      ZQpob2dlCmhvZ2UKaG9nZQpob2dlCmhvZ2UKaG9nZQpob2dlCmhvZ2UKaG9nZQpob2dlCmhvZ2UK
      aG9nZQpob2dlCmhvZ2UKaG9nZQpob2dlCmhvZ2UKaG9nZQpob2dlCmhvZ2UKaG9nZQpob2dlCmhv
      Z2UKaG9nZQpob2dlCmhvZ2UKaG9nZQpob2dlCmhvZ2UKaG9nZQpob2dlCmhvZ2UKaG9nZQpob2dl
      CmhvZ2UKaG9nZQpob2dlCmhvZ2UKaG9nZQpob2dlCmhvZ2UKaG9nZQpob2dlCmhvZ2UKaG9nZQpo
      b2dlCmhvZ2UKaG9nZQpob2dlCmhvZ2UKaG9nZQpob2dlCmhvZ2UKaG9nZQo=
```
