### PR TITLE
Add new auth method - Use json_key file of GCP's service account

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ Google Cloud Storage output plugin for [Embulk](https://github.com/embulk/embulk
 - **path_prefix**: Prefix of output keys (string, required)
 - **file_ext**: Extention of output file (string, required)
 - **content_type**: content type of output file (string, optional, default value is "application/octet-stream")
-- **auth_method**: Authentication method `private_key` or `compute_engine` (string, optional, default value is "private_key")
-- **service_account_email**: Google Cloud Platform service account email (string, required)
-- **p12_keyfile_path**: Private key file fullpath of Google Cloud Platform service account (string, required)
+- **auth_method**: Authentication method `private_key`, `json_key` or `compute_engine` (string, optional, default value is "private_key")
+- **service_account_email**: Google Cloud Platform service account email (string, required when auth_method is private_key)
+- **p12_keyfile**: Private key file fullpath of Google Cloud Platform service account (string, required when auth_method is private_key)
+- **json_keyfile** fullpath of json_key (string, required when auth_method is json_key)
 - **application_name**: Application name, anything you like (string, optional, default value is "embulk-output-gcs")
 
 ## Example
@@ -30,7 +31,7 @@ out:
   file_ext: .csv
   auth_method: `private_key` #default
   service_account_email: 'XYZ@developer.gserviceaccount.com'
-  p12_keyfile_path: '/path/to/private/key.p12'
+  p12_keyfile: '/path/to/private/key.p12'
   formatter:
     type: csv
     encoding: UTF-8
@@ -38,18 +39,56 @@ out:
 
 ## Authentication
 
-There are two methods supported to fetch access token for the service account.
+There are three methods supported to fetch access token for the service account.
 
-1. Public-Private key pair
-2. Pre-defined access token (Compute Engine only)
+1. Public-Private key pair of GCP(Google Cloud Platform)'s service account
+2. JSON key of GCP(Google Cloud Platform)'s service account
+3. Pre-defined access token (Google Compute Engine only)
 
-The examples above use the first one.  You first need to create a service account (client ID),
-download its private key and deploy the key with embulk.
+### Public-Private key pair of GCP's service account
+
+You first need to create a service account (client ID), download its private key and deploy the key with embulk.
+
+```yaml
+out:
+  type: gcs
+  auth_method: private_key
+  service_account_email: ABCXYZ123ABCXYZ123.gserviceaccount.com
+  p12_keyfile: /path/to/p12_keyfile.p12
+```
+
+### JSON key of GCP's service account
+
+You first need to create a service account (client ID), download its json key and deploy the key with embulk.
+
+```yaml
+out:
+  type: gcs
+  auth_method: json_key
+  json_keyfile: /path/to/json_keyfile.json
+```
+
+You can also embed contents of json_keyfile at config.yml.
+
+```yaml
+out:
+  type: gcs
+  auth_method: json_key
+  json_keyfile:
+    content: |
+      {
+          "private_key_id": "123456789",
+          "private_key": "-----BEGIN PRIVATE KEY-----\nABCDEF",
+          "client_email": "..."
+       }
+```
+
+### Pre-defined access token(GCE only)
 
 On the other hand, you don't need to explicitly create a service account for embulk when you
-run embulk in Google Compute Engine. In this second authentication method, you need to
-add the API scope "https://www.googleapis.com/auth/devstorage.read_write" to the scope list of your
-Compute Engine instance, then you can configure embulk like this.
+run embulk in Google Compute Engine. In this third authentication method, you need to
+add the API scope "https://www.googleapis.com/auth/bigquery" to the scope list of your
+Compute Engine VM instance, then you can configure embulk like this.
 
 [Setting the scope of service account access for instances](https://cloud.google.com/compute/docs/authentication)
 


### PR DESCRIPTION
**Notice** this pull-request depends on #5

I implemented new auth method that enable to use JSON key of GCP's service account.

pull-request #5 added support for LocalFile class. This allows us to embed authentication information in config file.

However, creating base64 of .p12 file is really annoying.

supporting new auth method is useful for upper case.
## Usage

```
out:
  type: gcs
  auth_method: json_key
  json_keyfile: /path/to/json_keyfile.json
```

or

```
out:
  type: gcs
  auth_method: json_key
  json_keyfile:
    content: |
      {
          "private_key_id": "123456789",
          "private_key": "-----BEGIN PRIVATE KEY-----\nABCDEF",
          "client_email": "..."
      }
```
