### PR TITLE
Fixed auth problem for MapReduce executor.

### DIFF
--- a/src/test/java/org/embulk/output/TestGcsOutputPlugin.java
+++ b/src/test/java/org/embulk/output/TestGcsOutputPlugin.java
@@ -377,14 +377,7 @@ public class TestGcsOutputPlugin
 
 	private ImmutableList<List<String>> getFileContentsFromGcs(String path) throws Exception
 	{
-		ConfigSource config = Exec.newConfigSource()
-			.set("in", inputConfig())
-			.set("parser", parserConfig(schemaConfig()))
-			.set("type", "gcs")
-			.set("bucket", GCP_BUCKET)
-			.set("path_prefix", "my-prefix")
-			.set("file_ext", ".csv")
-			.set("formatter", formatterConfig());
+		ConfigSource config = config();
 
 		PluginTask task = config.loadConfig(PluginTask.class);
 


### PR DESCRIPTION
If we are using Map-Reduce executor, `transaction()` and `Transactional.open()` is executed at different instances.

In this case, program could not read `private static GcsAuthentication auth;` and authorization will fail. I fixed it..
