### PR TITLE
Improve upload stability

### DIFF
--- a/src/main/java/org/embulk/output/GcsAuthentication.java
+++ b/src/main/java/org/embulk/output/GcsAuthentication.java
@@ -1,5 +1,6 @@
 package org.embulk.output;
 
+import com.google.api.client.auth.oauth2.TokenResponseException;
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.api.client.googleapis.compute.ComputeCredential;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
@@ -10,16 +11,21 @@ import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.storage.Storage;
 import com.google.api.services.storage.StorageScopes;
-import com.google.api.services.storage.model.Objects;
 import com.google.common.base.Optional;
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
+import org.embulk.config.ConfigException;
 import org.embulk.spi.Exec;
+import org.embulk.spi.util.RetryExecutor.RetryGiveupException;
+import org.embulk.spi.util.RetryExecutor.Retryable;
 import org.slf4j.Logger;
+import static org.embulk.spi.util.RetryExecutor.retryExecutor;
 
 import java.io.File;
 import java.io.FileInputStream;
 
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.security.GeneralSecurityException;
 import java.util.Collections;
 
@@ -74,13 +80,13 @@ public class GcsAuthentication
                                 StorageScopes.DEVSTORAGE_READ_WRITE
                         )
                 )
-                .setServiceAccountPrivateKeyFromP12File(new File(p12KeyFilePath.orNull()))
+                .setServiceAccountPrivateKeyFromP12File(new File(p12KeyFilePath.get()))
                 .build();
     }
 
     private GoogleCredential getServiceAccountCredentialFromJsonFile() throws IOException
     {
-        FileInputStream stream = new FileInputStream(jsonKeyFilePath.orNull());
+        FileInputStream stream = new FileInputStream(jsonKeyFilePath.get());
 
         return GoogleCredential.fromStream(stream, httpTransport, jsonFactory)
                 .createScoped(Collections.singleton(StorageScopes.DEVSTORAGE_READ_WRITE));
@@ -99,16 +105,84 @@ public class GcsAuthentication
         return credential;
     }
 
-    public Storage getGcsClient(String bucket) throws GoogleJsonResponseException, IOException
+    public Storage getGcsClient(final String bucket, int maxConnectionRetry) throws ConfigException, IOException
     {
-        Storage client = new Storage.Builder(httpTransport, jsonFactory, credentials)
-                .setApplicationName(applicationName)
-                .build();
+        try {
+            return retryExecutor()
+                    .withRetryLimit(maxConnectionRetry)
+                    .withInitialRetryWait(500)
+                    .withMaxRetryWait(30 * 1000)
+                    .runInterruptible(new Retryable<Storage>() {
+                        @Override
+                        public Storage call() throws IOException, RetryGiveupException
+                        {
+                            Storage client = new Storage.Builder(httpTransport, jsonFactory, credentials)
+                                    .setApplicationName(applicationName)
+                                    .build();
 
-        // For throw IOException when authentication is fail.
-        long maxResults = 1;
-        Objects objects = client.objects().list(bucket).setMaxResults(maxResults).execute();
+                            // For throw ConfigException when authentication is fail.
+                            long maxResults = 1;
+                            client.objects().list(bucket).setMaxResults(maxResults).execute();
 
-        return client;
+                            return client;
+                        }
+
+                        @Override
+                        public boolean isRetryableException(Exception exception)
+                        {
+                            if (exception instanceof GoogleJsonResponseException || exception instanceof TokenResponseException) {
+                                int statusCode;
+                                if (exception instanceof GoogleJsonResponseException) {
+                                    statusCode = ((GoogleJsonResponseException) exception).getDetails().getCode();
+                                }
+                                else {
+                                    statusCode = ((TokenResponseException) exception).getStatusCode();
+                                }
+                                if (statusCode / 100 == 4) {
+                                    return false;
+                                }
+                            }
+                            return true;
+                        }
+
+                        @Override
+                        public void onRetry(Exception exception, int retryCount, int retryLimit, int retryWait)
+                                throws RetryGiveupException
+                        {
+                            String message = String.format("GCS GET request failed. Retrying %d/%d after %d seconds. Message: %s: %s",
+                                    retryCount, retryLimit, retryWait / 1000, exception.getClass(), exception.getMessage());
+                            if (retryCount % 3 == 0) {
+                                log.warn(message, exception);
+                            }
+                            else {
+                                log.warn(message);
+                            }
+                        }
+
+                        @Override
+                        public void onGiveup(Exception firstException, Exception lastException)
+                                throws RetryGiveupException
+                        {
+                        }
+                    });
+        }
+        catch (RetryGiveupException ex) {
+            if (ex.getCause() instanceof GoogleJsonResponseException || ex.getCause() instanceof TokenResponseException) {
+                int statusCode = 0;
+                if (ex.getCause() instanceof GoogleJsonResponseException) {
+                    statusCode = ((GoogleJsonResponseException) ex.getCause()).getDetails().getCode();
+                }
+                else if (ex.getCause() instanceof TokenResponseException) {
+                    statusCode = ((TokenResponseException) ex.getCause()).getStatusCode();
+                }
+                if (statusCode / 100 == 4) {
+                    throw new ConfigException(ex);
+                }
+            }
+            throw Throwables.propagate(ex);
+        }
+        catch (InterruptedException ex) {
+            throw new InterruptedIOException();
+        }
     }
 }

--- a/src/main/java/org/embulk/output/GcsOutputPlugin.java
+++ b/src/main/java/org/embulk/output/GcsOutputPlugin.java
@@ -315,11 +315,6 @@ public class GcsOutputPlugin implements FileOutputPlugin
                 final InputStreamContent mediaContent = new InputStreamContent(contentType, inputStream);
                 mediaContent.setCloseInputStream(true);
 
-                StorageObject objectMetadata = new StorageObject();
-                objectMetadata.setName(path);
-
-                final Storage.Objects.Insert insert = client.objects().insert(bucket, objectMetadata, mediaContent);
-                insert.setDisableGZipContent(true);
                 return executor.submit(new Callable<StorageObject>() {
                     @Override
                     public StorageObject call() throws IOException

--- a/src/main/java/org/embulk/output/GcsOutputPlugin.java
+++ b/src/main/java/org/embulk/output/GcsOutputPlugin.java
@@ -226,9 +226,6 @@ public class GcsOutputPlugin implements FileOutputPlugin
             try {
                 tempFile = Exec.getTempFileSpace().createTempFile();
                 currentStream = new BufferedOutputStream(new FileOutputStream(tempFile));
-                String path = pathPrefix + String.format(sequenceFormat, taskIndex, fileIndex) + pathSuffix;
-                logger.info("Uploading '{}/{}'", bucket, path);
-                currentUpload = startUpload(path, contentType, tempFile);
                 fileIndex++;
             }
             catch (IOException ex) {
@@ -255,6 +252,11 @@ public class GcsOutputPlugin implements FileOutputPlugin
         @Override
         public void finish()
         {
+            String path = pathPrefix + String.format(sequenceFormat, taskIndex, fileIndex) + pathSuffix;
+            if (tempFile != null) {
+                currentUpload = startUpload(path, contentType, tempFile);
+            }
+
             closeCurrentUpload();
         }
 
@@ -320,6 +322,7 @@ public class GcsOutputPlugin implements FileOutputPlugin
                     public StorageObject call() throws IOException
                     {
                         try {
+                            logger.info("Uploading '{}/{}'", bucket, path);
                             return execUploadWithRetry(path, mediaContent);
                         }
                         finally {

--- a/src/main/java/org/embulk/output/GcsOutputPlugin.java
+++ b/src/main/java/org/embulk/output/GcsOutputPlugin.java
@@ -22,10 +22,15 @@ import org.embulk.spi.unit.LocalFile;
 import org.embulk.spi.util.RetryExecutor.RetryGiveupException;
 import org.embulk.spi.util.RetryExecutor.Retryable;
 import org.slf4j.Logger;
+import static org.embulk.spi.util.RetryExecutor.retryExecutor;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.PipedInputStream;
-import java.io.PipedOutputStream;
+import java.io.InterruptedIOException;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.List;
@@ -194,12 +199,14 @@ public class GcsOutputPlugin implements FileOutputPlugin
         private final String pathSuffix;
         private final String sequenceFormat;
         private final String contentType;
+        private final int maxConnectionRetry;
         private final List<StorageObject> storageObjects = new ArrayList<>();
 
         private int fileIndex = 0;
         private int callCount = 0;
-        private PipedOutputStream currentStream = null;
+        private BufferedOutputStream currentStream = null;
         private Future<StorageObject> currentUpload = null;
+        private File tempFile = null;
 
         TransactionalGcsFileOutput(PluginTask task, Storage client, int taskIndex)
         {
@@ -210,16 +217,23 @@ public class GcsOutputPlugin implements FileOutputPlugin
             this.pathSuffix = task.getFileNameExtension();
             this.sequenceFormat = task.getSequenceFormat();
             this.contentType = task.getContentType();
+            this.maxConnectionRetry = task.getMaxConnectionRetry();
         }
 
         public void nextFile()
         {
             closeCurrentUpload();
-            currentStream = new PipedOutputStream();
-            String path = pathPrefix + String.format(sequenceFormat, taskIndex, fileIndex) + pathSuffix;
-            logger.info("Uploading '{}/{}'", bucket, path);
-            currentUpload = startUpload(path, contentType, currentStream);
-            fileIndex++;
+            try {
+                tempFile = Exec.getTempFileSpace().createTempFile();
+                currentStream = new BufferedOutputStream(new FileOutputStream(tempFile));
+                String path = pathPrefix + String.format(sequenceFormat, taskIndex, fileIndex) + pathSuffix;
+                logger.info("Uploading '{}/{}'", bucket, path);
+                currentUpload = startUpload(path, contentType, tempFile);
+                fileIndex++;
+            }
+            catch (IOException ex) {
+                Throwables.propagate(ex);
+            }
         }
 
         @Override
@@ -271,6 +285,13 @@ public class GcsOutputPlugin implements FileOutputPlugin
                     currentStream = null;
                 }
 
+                if (tempFile != null) {
+                    if (!tempFile.delete()) {
+                        throw new IOException(String.format("Failed to delete temporary file %s", tempFile.getAbsolutePath()));
+                    }
+                    tempFile = null;
+                }
+
                 if (currentUpload != null) {
                     StorageObject obj = currentUpload.get();
                     storageObjects.add(obj);
@@ -285,13 +306,13 @@ public class GcsOutputPlugin implements FileOutputPlugin
             }
         }
 
-        private Future<StorageObject> startUpload(String path, String contentType, PipedOutputStream output)
+        private Future<StorageObject> startUpload(final String path, String contentType, File tempFile)
         {
             try {
                 final ExecutorService executor = Executors.newCachedThreadPool();
 
-                PipedInputStream inputStream = new PipedInputStream(output);
-                InputStreamContent mediaContent = new InputStreamContent(contentType, inputStream);
+                BufferedInputStream inputStream = new BufferedInputStream(new FileInputStream(tempFile));
+                final InputStreamContent mediaContent = new InputStreamContent(contentType, inputStream);
                 mediaContent.setCloseInputStream(true);
 
                 StorageObject objectMetadata = new StorageObject();
@@ -301,13 +322,10 @@ public class GcsOutputPlugin implements FileOutputPlugin
                 insert.setDisableGZipContent(true);
                 return executor.submit(new Callable<StorageObject>() {
                     @Override
-                    public StorageObject call() throws InterruptedException
+                    public StorageObject call() throws IOException
                     {
                         try {
-                            return insert.execute();
-                        }
-                        catch (IOException ex) {
-                            throw Throwables.propagate(ex);
+                            return execUploadWithRetry(path, mediaContent);
                         }
                         finally {
                             executor.shutdown();
@@ -317,6 +335,58 @@ public class GcsOutputPlugin implements FileOutputPlugin
             }
             catch (IOException ex) {
                 throw Throwables.propagate(ex);
+            }
+        }
+
+        private StorageObject execUploadWithRetry(final String path, final InputStreamContent mediaContent) throws IOException
+        {
+            try {
+                return retryExecutor()
+                    .withRetryLimit(maxConnectionRetry)
+                    .withInitialRetryWait(500)
+                    .withMaxRetryWait(30 * 1000)
+                    .runInterruptible(new Retryable<StorageObject>() {
+                    @Override
+                    public StorageObject call() throws IOException, RetryGiveupException
+                    {
+                        StorageObject objectMetadata = new StorageObject();
+                        objectMetadata.setName(path);
+
+                        final Storage.Objects.Insert insert = client.objects().insert(bucket, objectMetadata, mediaContent);
+                        insert.setDisableGZipContent(true);
+                        return insert.execute();
+                    }
+
+                    @Override
+                    public boolean isRetryableException(Exception exception)
+                    {
+                        return true;
+                    }
+
+                    @Override
+                    public void onRetry(Exception exception, int retryCount, int retryLimit, int retryWait) throws RetryGiveupException
+                    {
+                        String message = String.format("GCS put request failed. Retrying %d/%d after %d seconds. Message: %s: %s",
+                                        retryCount, retryLimit, retryWait / 1000, exception.getClass(), exception.getMessage());
+                        if (retryCount % 3 == 0) {
+                            logger.warn(message, exception);
+                        }
+                        else {
+                            logger.warn(message);
+                        }
+                    }
+
+                    @Override
+                    public void onGiveup(Exception firstException, Exception lastException) throws RetryGiveupException
+                    {
+                    }
+                });
+            }
+            catch (RetryGiveupException ex) {
+                throw Throwables.propagate(ex.getCause());
+            }
+            catch (InterruptedException ex) {
+                throw new InterruptedIOException();
             }
         }
     }

--- a/src/test/java/org/embulk/output/TestGcsAuthentication.java
+++ b/src/test/java/org/embulk/output/TestGcsAuthentication.java
@@ -1,12 +1,12 @@
 package org.embulk.output;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
-import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.storage.Storage;
 import com.google.common.base.Optional;
 
 import org.embulk.EmbulkTestRuntime;
 
+import org.embulk.config.ConfigException;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -81,8 +81,7 @@ public class TestGcsAuthentication
     }
 
     @Test
-    public void testGetGcsClientUsingServiceAccountCredentialSuccess()
-            throws NoSuchFieldException, IllegalAccessException, GeneralSecurityException, IOException
+    public void testGetGcsClientUsingServiceAccountCredentialSuccess() throws Exception
     {
         GcsAuthentication auth = new GcsAuthentication(
                 "private_key",
@@ -92,14 +91,13 @@ public class TestGcsAuthentication
                 GCP_APPLICATION_NAME
         );
 
-        Storage client = auth.getGcsClient(GCP_BUCKET);
+        Storage client = auth.getGcsClient(GCP_BUCKET, 3);
 
         assertEquals(Storage.class, client.getClass());
     }
 
-    @Test(expected = GoogleJsonResponseException.class)
-    public void testGetGcsClientUsingServiceAccountCredentialThrowJsonResponseException()
-            throws NoSuchFieldException, IllegalAccessException, GeneralSecurityException, IOException
+    @Test(expected = ConfigException.class)
+    public void testGetGcsClientUsingServiceAccountCredentialThrowConfigException() throws Exception
     {
         GcsAuthentication auth = new GcsAuthentication(
                 "private_key",
@@ -109,7 +107,7 @@ public class TestGcsAuthentication
                 GCP_APPLICATION_NAME
         );
 
-        Storage client = auth.getGcsClient("non-exists-bucket");
+        Storage client = auth.getGcsClient("non-exists-bucket", 3);
 
         assertEquals(Storage.class, client.getClass());
     }
@@ -146,8 +144,7 @@ public class TestGcsAuthentication
     }
 
     @Test
-    public void testGetServiceAccountCredentialFromJsonSuccess()
-            throws NoSuchFieldException, IllegalAccessException, GeneralSecurityException, IOException
+    public void testGetServiceAccountCredentialFromJsonSuccess() throws Exception
     {
         GcsAuthentication auth = new GcsAuthentication(
                 "json_key",
@@ -157,14 +154,13 @@ public class TestGcsAuthentication
                 GCP_APPLICATION_NAME
         );
 
-        Storage client = auth.getGcsClient(GCP_BUCKET);
+        Storage client = auth.getGcsClient(GCP_BUCKET, 3);
 
         assertEquals(Storage.class, client.getClass());
     }
 
-    @Test(expected = GoogleJsonResponseException.class)
-    public void testGetServiceAccountCredentialFromJsonThrowGoogleJsonResponseException()
-            throws NoSuchFieldException, IllegalAccessException, GeneralSecurityException, IOException
+    @Test(expected = ConfigException.class)
+    public void testGetServiceAccountCredentialFromJsonThrowConfigException() throws Exception
     {
         GcsAuthentication auth = new GcsAuthentication(
                 "json_key",
@@ -174,6 +170,6 @@ public class TestGcsAuthentication
                 GCP_APPLICATION_NAME
         );
 
-        Storage client = auth.getGcsClient("non-exists-bucket");
+        Storage client = auth.getGcsClient("non-exists-bucket", 3);
     }
 }


### PR DESCRIPTION
Note: this PR is based on #13.

In our Embulk environment, embulk-output-gcs sometimes fails for the reason of SocketTimeout error.
To avoid this error, I added retry logic to plugin using [RetryExcecutor](https://github.com/embulk/embulk/blob/master/embulk-core/src/main/java/org/embulk/spi/util/RetryExecutor.java) provided by embulk-core.
- retry logic for GCS client creating logic. b7e4216
- retry logic for file upload logic. e0937f7

Plugin will try to re-connect max 10 times with exponential backoff when something error happens. So this type of error should decrease.
### Stacktrace

``` java
java.lang.RuntimeException: java.util.concurrent.ExecutionException: java.lang.RuntimeException: java.net.SocketTimeoutException: Read timed out
org.embulk.exec.PartialExecutionException: java.lang.RuntimeException: java.util.concurrent.ExecutionException: java.lang.RuntimeException: java.net.SocketTimeoutException: Read timed out
    at org.embulk.exec.BulkLoader$LoaderState.buildPartialExecuteException(BulkLoader.java:363)
    at org.embulk.exec.BulkLoader.doRun(BulkLoader.java:572)
    at org.embulk.exec.BulkLoader.access$000(BulkLoader.java:33)
    at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:374)
    at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:370)
    at org.embulk.spi.Exec.doWith(Exec.java:25)
    at org.embulk.exec.BulkLoader.run(BulkLoader.java:370)
    at org.embulk.EmbulkEmbed.run(EmbulkEmbed.java:180)
    ... ...
Caused by: java.lang.RuntimeException: java.util.concurrent.ExecutionException: java.lang.RuntimeException: java.net.SocketTimeoutException: Read timed out
    at com.google.common.base.Throwables.propagate(Throwables.java:160)
    at org.embulk.output.GcsOutputPlugin$TransactionalGcsFileOutput.closeCurrentUpload(GcsOutputPlugin.java:257)
    at org.embulk.output.GcsOutputPlugin$TransactionalGcsFileOutput.finish(GcsOutputPlugin.java:222)
    at org.embulk.spi.util.FileOutputOutputStream.close(FileOutputOutputStream.java:104)
    at sun.nio.cs.StreamEncoder.implClose(StreamEncoder.java:320)
    at sun.nio.cs.StreamEncoder.close(StreamEncoder.java:149)
    at java.io.OutputStreamWriter.close(OutputStreamWriter.java:233)
    at java.io.BufferedWriter.close(BufferedWriter.java:266)
    at org.embulk.spi.util.LineEncoder.finish(LineEncoder.java:100)
    at org.embulk.standards.CsvFormatterPlugin$1.finish(CsvFormatterPlugin.java:217)
    at org.embulk.spi.FileOutputRunner$DelegateTransactionalPageOutput.finish(FileOutputRunner.java:172)
    at org.embulk.spi.PageBuilder.finish(PageBuilder.java:244)
    at org.embulk.parser.msgpack.MsgpackParserPlugin.run(MsgpackParserPlugin.java:245)
    at org.embulk.spi.FileInputRunner.run(FileInputRunner.java:154)
    at org.embulk.spi.util.Executors.process(Executors.java:67)
    at org.embulk.spi.util.Executors.process(Executors.java:42)
    at org.embulk.exec.LocalExecutorPlugin$DirectExecutor$1.call(LocalExecutorPlugin.java:184)
    at org.embulk.exec.LocalExecutorPlugin$DirectExecutor$1.call(LocalExecutorPlugin.java:180)
    at java.util.concurrent.FutureTask.run(FutureTask.java:262)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
    at java.lang.Thread.run(Thread.java:745)
    Suppressed: java.lang.IllegalStateException: Current state = FLUSHED, new state = CODING_END
        at java.nio.charset.CharsetEncoder.throwIllegalStateException(CharsetEncoder.java:968)
        at java.nio.charset.CharsetEncoder.encode(CharsetEncoder.java:554)
        at sun.nio.cs.StreamEncoder.flushLeftoverChar(StreamEncoder.java:242)
        at sun.nio.cs.StreamEncoder.implClose(StreamEncoder.java:301)
        at sun.nio.cs.StreamEncoder.close(StreamEncoder.java:149)
        at java.io.OutputStreamWriter.close(OutputStreamWriter.java:233)
        at java.io.BufferedWriter.close(BufferedWriter.java:266)
        at org.embulk.spi.util.LineEncoder.close(LineEncoder.java:114)
        at org.embulk.standards.CsvFormatterPlugin$1.close(CsvFormatterPlugin.java:222)
        at org.embulk.spi.FileOutputRunner$DelegateTransactionalPageOutput.close(FileOutputRunner.java:178)
        at org.embulk.spi.PageBuilder.close(PageBuilder.java:255)
        at org.embulk.parser.msgpack.MsgpackParserPlugin.run(MsgpackParserPlugin.java:247)
        ... 9 more
    Suppressed: java.lang.IllegalStateException: Current state = FLUSHED, new state = CODING_END
        at java.nio.charset.CharsetEncoder.throwIllegalStateException(CharsetEncoder.java:968)
        at java.nio.charset.CharsetEncoder.encode(CharsetEncoder.java:554)
        at sun.nio.cs.StreamEncoder.flushLeftoverChar(StreamEncoder.java:242)
        at sun.nio.cs.StreamEncoder.implClose(StreamEncoder.java:301)
        at sun.nio.cs.StreamEncoder.close(StreamEncoder.java:149)
        at java.io.OutputStreamWriter.close(OutputStreamWriter.java:233)
        at java.io.BufferedWriter.close(BufferedWriter.java:266)
        at org.embulk.spi.util.LineEncoder.close(LineEncoder.java:114)
        at org.embulk.standards.CsvFormatterPlugin$1.close(CsvFormatterPlugin.java:222)
        at org.embulk.spi.FileOutputRunner$DelegateTransactionalPageOutput.close(FileOutputRunner.java:178)
        at org.embulk.spi.CloseResource.close(CloseResource.java:34)
        at org.embulk.spi.util.Executors.process(Executors.java:81)
        ... 7 more
```
