### PR TITLE
Improve upload stability

### DIFF
--- a/src/main/java/org/embulk/output/GcsOutputPlugin.java
+++ b/src/main/java/org/embulk/output/GcsOutputPlugin.java
@@ -295,13 +295,6 @@ public class GcsOutputPlugin implements FileOutputPlugin
         private void closeCurrentUpload()
         {
             try {
-                if (tempFile != null) {
-                    if (!tempFile.delete()) {
-                        throw new IOException(String.format("Failed to delete temporary file %s", tempFile.getAbsolutePath()));
-                    }
-                    tempFile = null;
-                }
-
                 if (currentUpload != null) {
                     StorageObject obj = currentUpload.get();
                     storageObjects.add(obj);
@@ -311,7 +304,7 @@ public class GcsOutputPlugin implements FileOutputPlugin
 
                 callCount = 0;
             }
-            catch (InterruptedException | ExecutionException | IOException ex) {
+            catch (InterruptedException | ExecutionException ex) {
                 throw Throwables.propagate(ex);
             }
         }


### PR DESCRIPTION
I sent similar PRs few times.
Plugin still sometimes returns following failures.

```
2017-01-15 13:20:50.521 +0000 [INFO] (0013:task-0000): Uploading '/path/to/remote.txt'
2017-01-15 13:21:14.753 +0000 [INFO] (0001:transaction): {done:  1 / 1, running: 0}
java.lang.RuntimeException: java.io.IOException: Read end dead
org.embulk.exec.PartialExecutionException: java.lang.RuntimeException: java.io.IOException: Read end dead
```

I guess this failure happens InputStream was already closed before retry.
To solve this problem, I added 2 changes.

1. Force to retry including InputStream re-open
  Current implementation tries only file upload when retrying. This means plugin uses input stream that is already opened.
  I changed to force to re-open InputStream.
2. ~~Compare Hash(MD5) between local file and remote5 after upload completed.~~
   ~~If hash is unmatched, plugin will retry to upload until hash is matched.~~

   Only enable hash value logging.