### PR TITLE
Fix NPE when authentication

### DIFF
--- a/src/main/java/org/embulk/output/GcsAuthentication.java
+++ b/src/main/java/org/embulk/output/GcsAuthentication.java
@@ -133,6 +133,9 @@ public class GcsAuthentication
                             if (exception instanceof GoogleJsonResponseException || exception instanceof TokenResponseException) {
                                 int statusCode;
                                 if (exception instanceof GoogleJsonResponseException) {
+                                    if (((GoogleJsonResponseException) exception).getDetails() == null) {
+                                        return true;
+                                    }
                                     statusCode = ((GoogleJsonResponseException) exception).getDetails().getCode();
                                 }
                                 else {
@@ -170,7 +173,9 @@ public class GcsAuthentication
             if (ex.getCause() instanceof GoogleJsonResponseException || ex.getCause() instanceof TokenResponseException) {
                 int statusCode = 0;
                 if (ex.getCause() instanceof GoogleJsonResponseException) {
-                    statusCode = ((GoogleJsonResponseException) ex.getCause()).getDetails().getCode();
+                    if (((GoogleJsonResponseException) ex.getCause()).getDetails() != null) {
+                        statusCode = ((GoogleJsonResponseException) ex.getCause()).getDetails().getCode();
+                    }
                 }
                 else if (ex.getCause() instanceof TokenResponseException) {
                     statusCode = ((TokenResponseException) ex.getCause()).getStatusCode();

--- a/src/main/java/org/embulk/output/GcsAuthentication.java
+++ b/src/main/java/org/embulk/output/GcsAuthentication.java
@@ -134,6 +134,11 @@ public class GcsAuthentication
                                 int statusCode;
                                 if (exception instanceof GoogleJsonResponseException) {
                                     if (((GoogleJsonResponseException) exception).getDetails() == null) {
+                                        String content = "";
+                                        if (((GoogleJsonResponseException) exception).getContent() != null) {
+                                            content = ((GoogleJsonResponseException) exception).getContent();
+                                        }
+                                        log.warn("Invalid response was returned : {}", content);
                                         return true;
                                     }
                                     statusCode = ((GoogleJsonResponseException) exception).getDetails().getCode();


### PR DESCRIPTION
I got NPE when I was trying with embulk-output-gcs.
```
java.lang.NullPointerException
org.embulk.exec.PartialExecutionException: java.lang.NullPointerException
	...
Caused by: java.lang.NullPointerException
	at org.embulk.output.GcsAuthentication$1.isRetryableException(GcsAuthentication.java:136)
	at org.embulk.spi.util.RetryExecutor.run(RetryExecutor.java:105)
	at org.embulk.spi.util.RetryExecutor.runInterruptible(RetryExecutor.java:77)
	at org.embulk.output.GcsAuthentication.getGcsClient(GcsAuthentication.java:115)
	at org.embulk.output.GcsOutputPlugin.createClient(GcsOutputPlugin.java:178)
	at org.embulk.output.GcsOutputPlugin.open(GcsOutputPlugin.java:154)
	at org.embulk.spi.FileOutputRunner.open(FileOutputRunner.java:133)
	at org.embulk.spi.util.Executors.process(Executors.java:56)
	at org.embulk.spi.util.Executors.process(Executors.java:42)
	at org.embulk.exec.LocalExecutorPlugin$DirectExecutor$1.call(LocalExecutorPlugin.java:184)
	at org.embulk.exec.LocalExecutorPlugin$DirectExecutor$1.call(LocalExecutorPlugin.java:180)
	at java.util.concurrent.FutureTask.run(FutureTask.java:262)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
	at java.lang.Thread.run(Thread.java:745)
```

I couldn't reproduce this problem.
But I found that `GoogleJsonResponseException.getDetails()` returns null when response is not JSON string.

```java
  /**
   * Returns the Google JSON error details or {@code null} for none (for example if HTTP response is not
   * JSON).
   */
  public final GoogleJsonError getDetails() {
    return details;
  }

```
https://github.com/google/google-api-java-client/blob/dev/google-api-client/src/main/java/com/google/api/client/googleapis/json/GoogleJsonResponseException.java#L73

I changed the code to force to retry when `GoogleJsonResponseException.getDetails()` returns null.