### PR TITLE
Change target file name that unit test try to load after uploading

### DIFF
--- a/src/test/java/org/embulk/output/TestGcsOutputPlugin.java
+++ b/src/test/java/org/embulk/output/TestGcsOutputPlugin.java
@@ -70,7 +70,7 @@ public class TestGcsOutputPlugin
         assumeNotNull(GCP_EMAIL, GCP_P12_KEYFILE, GCP_JSON_KEYFILE, GCP_BUCKET);
 
         GCP_BUCKET_DIRECTORY = System.getenv("GCP_BUCKET_DIRECTORY") != null ? getDirectory(System.getenv("GCP_BUCKET_DIRECTORY")) : getDirectory("");
-        GCP_PATH_PREFIX = GCP_BUCKET_DIRECTORY + "sample_";
+        GCP_PATH_PREFIX = GCP_BUCKET_DIRECTORY + "output_";
         LOCAL_PATH_PREFIX = GcsOutputPlugin.class.getClassLoader().getResource("sample_01.csv").getPath();
         GCP_APPLICATION_NAME = "embulk-output-gcs";
     }
@@ -275,7 +275,7 @@ public class TestGcsOutputPlugin
         output.finish();
         output.commit();
 
-        String remotePath = GCP_PATH_PREFIX + String.format(task.getSequenceFormat(), 0, 0) + task.getFileNameExtension();
+        String remotePath = GCP_PATH_PREFIX + String.format(task.getSequenceFormat(), 0, 1) + task.getFileNameExtension();
         assertRecords(remotePath);
     }
 


### PR DESCRIPTION
This plugin tests upload result is expected or not after upload to Google Cloud Storage.

Upload file will be generated with name "sample_.000.01.csv".
But unit test actually tries to load "sample_.000.00.csv".
I didn't noticed because "sample_.000.00.csv" exists at my GCS bucket.

Additionally, both of embulk-output-gcs and embulk-input-gcs uses same environmental variables `GCP_BUCKET_DIRECTORY`.
This causes unit test failure due to file name confliction if developer has same both of plugin at their environment.

I fixed it.