### PR TITLE
Fix remote path generation logic

### DIFF
--- a/src/main/java/org/embulk/output/GcsOutputPlugin.java
+++ b/src/main/java/org/embulk/output/GcsOutputPlugin.java
@@ -419,6 +419,13 @@ public class GcsOutputPlugin implements FileOutputPlugin
         }
     }
 
+    /**
+     * GCS has character limitation in object names.
+     * @see https://cloud.google.com/storage/docs/naming#objectnames
+     * Although "." isn't listed at above pages, we can't access "./" path from GUI console.
+     * And in many cases, user don't intend of creating "/" directory under the bucket.
+     * This method normalizes path when it contains "./" and "/" and its variations at the beginning
+     */
     private static String generateRemotePath(String pathPrefix, String sequenceFormat, int taskIndex, int fileIndex, String pathSuffix)
     {
         String path = pathPrefix + String.format(sequenceFormat, taskIndex, fileIndex) + pathSuffix;

--- a/src/main/java/org/embulk/output/GcsOutputPlugin.java
+++ b/src/main/java/org/embulk/output/GcsOutputPlugin.java
@@ -422,7 +422,7 @@ public class GcsOutputPlugin implements FileOutputPlugin
     private static String generateRemotePath(String pathPrefix, String sequenceFormat, int taskIndex, int fileIndex, String pathSuffix)
     {
         String path = pathPrefix + String.format(sequenceFormat, taskIndex, fileIndex) + pathSuffix;
-        return path.replaceFirst("\\.*/*", "");
+        return path.replaceFirst("^\\.*/*", "");
     }
 
     public enum AuthMethod

--- a/src/main/java/org/embulk/output/GcsOutputPlugin.java
+++ b/src/main/java/org/embulk/output/GcsOutputPlugin.java
@@ -255,7 +255,7 @@ public class GcsOutputPlugin implements FileOutputPlugin
         @Override
         public void finish()
         {
-            String path = pathPrefix + String.format(sequenceFormat, taskIndex, fileIndex) + pathSuffix;
+            String path = generateRemotePath(pathPrefix, sequenceFormat, taskIndex, fileIndex, pathSuffix);
             close();
             if (tempFile != null) {
                 currentUpload = startUpload(path);
@@ -417,6 +417,12 @@ public class GcsOutputPlugin implements FileOutputPlugin
                 throw new ConfigException("MD5 algorism not found");
             }
         }
+    }
+
+    private static String generateRemotePath(String pathPrefix, String sequenceFormat, int taskIndex, int fileIndex, String pathSuffix)
+    {
+        String path = pathPrefix + String.format(sequenceFormat, taskIndex, fileIndex) + pathSuffix;
+        return path.replaceFirst("\\.*/*", "");
     }
 
     public enum AuthMethod

--- a/src/test/java/org/embulk/output/TestGcsOutputPlugin.java
+++ b/src/test/java/org/embulk/output/TestGcsOutputPlugin.java
@@ -291,6 +291,10 @@ public class TestGcsOutputPlugin
         assertEquals("sample.000.01.csv", method.invoke(plugin, "../sample", task.getSequenceFormat(), 0, 1, ".csv"));
         assertEquals("sample.000.01.csv", method.invoke(plugin, "//sample", task.getSequenceFormat(), 0, 1, ".csv"));
         assertEquals("path/to/sample.000.01.csv", method.invoke(plugin, "/path/to/sample", task.getSequenceFormat(), 0, 1, ".csv"));
+        assertEquals("path/to/./sample.000.01.csv", method.invoke(plugin, "path/to/./sample", task.getSequenceFormat(), 0, 1, ".csv"));
+        assertEquals("path/to/../sample.000.01.csv", method.invoke(plugin, "path/to/../sample", task.getSequenceFormat(), 0, 1, ".csv"));
+        assertEquals("sample.000.01.csv", method.invoke(plugin, "....../sample", task.getSequenceFormat(), 0, 1, ".csv"));
+        assertEquals("sample.000.01.csv", method.invoke(plugin, "......///sample", task.getSequenceFormat(), 0, 1, ".csv"));
     }
 
     public ConfigSource config()

--- a/src/test/java/org/embulk/output/TestGcsOutputPlugin.java
+++ b/src/test/java/org/embulk/output/TestGcsOutputPlugin.java
@@ -279,6 +279,20 @@ public class TestGcsOutputPlugin
         assertRecords(remotePath);
     }
 
+    @Test
+    public void testGenerateRemotePath() throws Exception
+    {
+        ConfigSource configSource = config();
+        PluginTask task = configSource.loadConfig(PluginTask.class);
+        Method method = GcsOutputPlugin.class.getDeclaredMethod("generateRemotePath", String.class, String.class, int.class, int.class, String.class);
+        method.setAccessible(true);
+        assertEquals("sample.000.01.csv", method.invoke(plugin, "/sample", task.getSequenceFormat(), 0, 1, ".csv"));
+        assertEquals("sample.000.01.csv", method.invoke(plugin, "./sample", task.getSequenceFormat(), 0, 1, ".csv"));
+        assertEquals("sample.000.01.csv", method.invoke(plugin, "../sample", task.getSequenceFormat(), 0, 1, ".csv"));
+        assertEquals("sample.000.01.csv", method.invoke(plugin, "//sample", task.getSequenceFormat(), 0, 1, ".csv"));
+        assertEquals("path/to/sample.000.01.csv", method.invoke(plugin, "/path/to/sample", task.getSequenceFormat(), 0, 1, ".csv"));
+    }
+
     public ConfigSource config()
     {
         return Exec.newConfigSource()


### PR DESCRIPTION
GCS SDK allows to create "./" and "/" directory under buckets when user set path that starts with them at `path_prefix` option.

e.g.
```yaml
out:
  type: gcs
  path_prefix: /output.csv
  path_prefix: ./output.csv
```

But we can't access to "./" from console and I don't think user intended to create "/" directory.

I changed implementation to remove "./" and "/" if `path_prefix` begins with them.