### PR TITLE
Only build with Java8 and fix Travis CI Failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: java
 jdk:
 - oraclejdk8
-- oraclejdk7
-- openjdk7
 env:
   global:
   - GCP_EMAIL=account-2@embulk-output-gcs-test.iam.gserviceaccount.com

--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,8 @@ configurations {
     provided
 }
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 version = "0.4.1"
 


### PR DESCRIPTION
I got CI failure only with Java7
https://travis-ci.org/embulk/embulk-output-gcs/builds/409700434

Travis had stopped to support Java7 and it's time to remove it from .travis.yml
Additionally, We're going to support Java8 with Embulk and its plugins. I updated build.gradle.

e.g. https://github.com/embulk/embulk-input-gcs/pull/35