### PR TITLE
Move its Java package to org.embulk.output.gcs from org.embulk.output

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ dependencies {
 }
 
 embulkPlugin {
-    mainClass = "org.embulk.output.GcsOutputPlugin"
+    mainClass = "org.embulk.output.gcs.GcsOutputPlugin"
     category = "output"
     type = "gcs"
 }

--- a/src/main/java/org/embulk/output/gcs/AuthMethod.java
+++ b/src/main/java/org/embulk/output/gcs/AuthMethod.java
@@ -1,4 +1,4 @@
-package org.embulk.output;
+package org.embulk.output.gcs;
 
 public enum AuthMethod
 {

--- a/src/main/java/org/embulk/output/gcs/GcsAuthentication.java
+++ b/src/main/java/org/embulk/output/gcs/GcsAuthentication.java
@@ -1,4 +1,4 @@
-package org.embulk.output;
+package org.embulk.output.gcs;
 
 import com.google.api.client.auth.oauth2.TokenResponseException;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;

--- a/src/main/java/org/embulk/output/gcs/GcsOutputPlugin.java
+++ b/src/main/java/org/embulk/output/gcs/GcsOutputPlugin.java
@@ -1,4 +1,4 @@
-package org.embulk.output;
+package org.embulk.output.gcs;
 
 import com.google.cloud.storage.Storage;
 import com.google.common.annotations.VisibleForTesting;

--- a/src/main/java/org/embulk/output/gcs/GcsTransactionalFileOutput.java
+++ b/src/main/java/org/embulk/output/gcs/GcsTransactionalFileOutput.java
@@ -1,4 +1,4 @@
-package org.embulk.output;
+package org.embulk.output.gcs;
 
 import com.google.cloud.WriteChannel;
 import com.google.cloud.storage.Blob;
@@ -17,7 +17,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.embulk.output.GcsOutputPlugin.CONFIG_MAPPER_FACTORY;
+import static org.embulk.output.gcs.GcsOutputPlugin.CONFIG_MAPPER_FACTORY;
 
 public class GcsTransactionalFileOutput implements TransactionalFileOutput
 {

--- a/src/main/java/org/embulk/output/gcs/PluginTask.java
+++ b/src/main/java/org/embulk/output/gcs/PluginTask.java
@@ -1,4 +1,4 @@
-package org.embulk.output;
+package org.embulk.output.gcs;
 
 import org.embulk.util.config.Config;
 import org.embulk.util.config.ConfigDefault;

--- a/src/test/java/org/embulk/output/gcs/TestGcsAuthentication.java
+++ b/src/test/java/org/embulk/output/gcs/TestGcsAuthentication.java
@@ -1,4 +1,4 @@
-package org.embulk.output;
+package org.embulk.output.gcs;
 
 import com.google.common.base.Throwables;
 import org.embulk.EmbulkTestRuntime;
@@ -10,8 +10,8 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
-import static org.embulk.output.GcsOutputPlugin.CONFIG_MAPPER;
-import static org.embulk.output.GcsOutputPlugin.CONFIG_MAPPER_FACTORY;
+import static org.embulk.output.gcs.GcsOutputPlugin.CONFIG_MAPPER;
+import static org.embulk.output.gcs.GcsOutputPlugin.CONFIG_MAPPER_FACTORY;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeNotNull;
 

--- a/src/test/java/org/embulk/output/gcs/TestGcsOutputPlugin.java
+++ b/src/test/java/org/embulk/output/gcs/TestGcsOutputPlugin.java
@@ -1,4 +1,4 @@
-package org.embulk.output;
+package org.embulk.output.gcs;
 
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
@@ -29,8 +29,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import static org.embulk.output.GcsOutputPlugin.CONFIG_MAPPER;
-import static org.embulk.output.GcsOutputPlugin.CONFIG_MAPPER_FACTORY;
+import static org.embulk.output.gcs.GcsOutputPlugin.CONFIG_MAPPER;
+import static org.embulk.output.gcs.GcsOutputPlugin.CONFIG_MAPPER_FACTORY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;


### PR DESCRIPTION
Moving its Java package to its own: `org.embulk.output` -> `org.embulk.output.gcs`

It will break compatibility from other plugins that depend on `embulk-output-gcs`. But, we have to do it because later versions of Java do not allow multiple JAR files have the same Java package. :(