### PR TITLE
Enhance close writer channel

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 group = "org.embulk"
-version = "0.6.0-SNAPSHOT"
+version = "0.7.0-SNAPSHOT"
 description = "Dumps records to Google Cloud Storage."
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/org/embulk/output/gcs/GcsTransactionalFileOutput.java
+++ b/src/main/java/org/embulk/output/gcs/GcsTransactionalFileOutput.java
@@ -67,6 +67,7 @@ public class GcsTransactionalFileOutput implements TransactionalFileOutput
     @Override
     public void nextFile()
     {
+        closeCurrentWriter();
         try {
             String blobName = generateRemotePath(pathPrefix, sequenceFormat, taskIndex, fileIndex, pathSuffix);
             blobId = BlobId.of(bucket, blobName);
@@ -128,6 +129,7 @@ public class GcsTransactionalFileOutput implements TransactionalFileOutput
     @Override
     public void close()
     {
+        closeCurrentWriter();
     }
 
     @Override


### PR DESCRIPTION
There is the case that the read timeout can occur at this line (https://github.com/embulk/embulk-output-gcs/blob/master/src/main/java/org/embulk/output/gcs/GcsTransactionalFileOutput.java#L85), and the embulk will try to close the writer channel at (https://github.com/embulk/embulk-output-gcs/blob/master/src/main/java/org/embulk/output/gcs/GcsTransactionalFileOutput.java#L124). However, calling the method `writer.close()` at (https://github.com/embulk/embulk-output-gcs/blob/master/src/main/java/org/embulk/output/gcs/GcsTransactionalFileOutput.java#L158) can throw StorageException. This PR will change the way to handle exception from IOException to Exception, so that it can handle both IOException and StorageException.